### PR TITLE
implemented working example in htcondor & slurm

### DIFF
--- a/master_study/001_make_folders.py
+++ b/master_study/001_make_folders.py
@@ -9,6 +9,7 @@ import itertools
 import numpy as np
 import yaml
 from user_defined_functions import generate_run_sh
+from user_defined_functions import generate_run_sh_htc
 
 # Import the configuration
 config=yaml.safe_load(open('config.yaml'))
@@ -46,6 +47,7 @@ print("--- %s seconds ---" % (time.time() - start_time))
 
 # From python objects we move the nodes to the file-system.
 start_time = time.time()
-root.make_folders(generate_run_sh)
+#root.make_folders(generate_run_sh)
+root.make_folders(generate_run_sh_htc)
 print('The tree folders are ready.')
 print("--- %s seconds ---" % (time.time() - start_time))

--- a/master_study/001_make_folders.py
+++ b/master_study/001_make_folders.py
@@ -17,23 +17,28 @@ config=yaml.safe_load(open('config.yaml'))
 
 # The user defines the variable to scan
 # machine parameters scans
-qx0 = np.arange(62.305, 62.330, 0.001)[::20]
-qy0 = np.arange(60.305, 60.330, 0.001)[::20]
+qx0 = np.arange(62.305, 62.330, 0.001)[:]
+qy0 = np.arange(60.305, 60.330, 0.001)[:]
+
+study_name = "HL_tunescan_20cm"
 
 children={}
+children[study_name] = {}
+children[study_name]["children"] = {}
+
 for optics_job, (myq1, myq2) in enumerate(itertools.product(qx0, qy0)):
     optics_children={}
-    children[f'{optics_job:03}'] = {
+    children[study_name]["children"][f'madx_{optics_job:03}'] = {
                                     'qx0':float(myq1),
                                     'qy0':float(myq2),
                                     'children':optics_children}
     for track_job in range(15):
-        optics_children[f'{track_job:03}'] = {
+        optics_children[f'xsuite_{track_job:03}'] = {
                     'particle_file': ('../../'
                                    f'distrib_abc/{track_job:03}.parquet'),
                     'xline_json': ('../xsuite_lines/'
                                   'line_bb_for_tracking.json'),
-                    'n_turns': int(1000)}
+                    'n_turns': int(1000000)}
 
 if config['root']['use_yaml_children']== False:
     config['root']['children'] = children

--- a/master_study/002_chronjob.py
+++ b/master_study/002_chronjob.py
@@ -37,9 +37,12 @@ from pathlib import Path
 #            print(node.get_absolute_path())
 
 class cluster():
-
     def __init__(self, run_on='local_pc'):
-        self.run_on=run_on
+       if run_on in ['local_pc', 'htc', 'slurm']:
+            self.run_on=run_on
+       else:
+            import sys
+            sys.exit('Error: Submission mode specified is not yet implemented')
 
     def create_sub_file(self, list_of_nodes, filename='file.sub'):
         running_jobs=self.running_jobs()
@@ -56,6 +59,8 @@ class cluster():
                 fid.write('# Running on local pc\n')
             elif self.run_on == 'lsf':
                 fid.write('# Running on LSF \n')
+            elif self.run_on == 'slurm':
+                fid.write('# Running on SLURM \n')
             elif self.run_on == 'htc':
                 fid.write('# This is a HTCondor submission file\n')
                 fid.write('error  = error.txt\n')
@@ -82,6 +87,9 @@ class cluster():
                         fid.write("bsub -n 2 -q hpc_acc "
                                 # "-e error.txt -o output.txt "
                                  f"{node.get_abs_path()}/run.sh\n")
+                    elif self.run_on == 'slurm':
+                        fid.write("sbatch --ntasks=2 --partition=slurm_hpc_acc --output=output.txt "
+                                 f"{node.get_abs_path()}/run.sh\n")
                     elif self.run_on == 'htc':
                         # initialdir is needed so that each job has it own output, error and log.txt
                         fid.write( "initialdir = "
@@ -94,6 +102,8 @@ class cluster():
                 fid.write(f'#{self.run_on}\n')
             elif self.run_on == 'lsf':
                 fid.write(f'#{self.run_on}\n')
+            elif self.run_on == 'slurm':
+                fid.write(f'#{self.run_on}\n')
             elif self.run_on == 'htc':
                 fid.write(f'#{self.run_on}\n')
 
@@ -101,6 +111,8 @@ class cluster():
         if self.run_on == 'local_pc':
             os.system(f'bash {filename}')
         elif self.run_on == 'lsf':
+            os.system(f'bash {filename}')
+        elif self.run_on == 'slurm':
             os.system(f'bash {filename}')
         elif self.run_on == 'htc':
             os.system(f'condor_submit {filename}')
@@ -123,6 +135,8 @@ class cluster():
 
             return my_list
         elif self.run_on == 'lsf':
+            return []
+        elif self.run_on == 'slurm':
             return []
         elif self.run_on == 'htc':
             return []

--- a/master_study/003_postprocessing.py
+++ b/master_study/003_postprocessing.py
@@ -15,44 +15,51 @@ import time
 start = time.time()
 
 
-my_study='.'
+my_study='HL_tunescan_20cm'
 #my_study='./full_tune_scan_wfix'
 #my_study='./full_tune_scan_wfix_more_particles'
 #my_study='./full_tune_scan_wfix_more_particles_tunes_as_sixt'
-
+problematic = []
 try:
-    root=tree_maker.tree_from_json(f'{my_study}/tree_maker.json')
+    root=tree_maker.tree_from_json(f'tree_maker.json')
 except Exception as e:
     print(e)
     print('Probably you forgot to edit the address of you json file...')
 
 my_list=[]
-if root.has_been('completed'):
-    print('All descendants of root are completed!')
+#if root.has_been('completed'):
+#    print('All descendants of root are completed!')
+if True:
     for node in root.generation(2):
-        node_df = pd.read_parquet(f'{node.get_abs_path()}/final_summ_BBOFF.parquet')
+        #node_df = pd.read_parquet(f'{node.get_abs_path()}/final_summ_BBOFF.parquet')
         with open(f'{node.get_abs_path()}/config.yaml','r') as fid:
             config_parent=yaml.safe_load(fid)
-        node_df['path']= f'{node.get_abs_path()}'
+        #node_df['path']= f'{node.get_abs_path()}'
         for node_child in node.children:
         #os.sytem(f'bsub cd {node.path} &&  {node.path_template} ')
         #my_list.append(pd.read_parquet(f'{node.path}/test.parquet', columns=['x']).iloc[-1].x)
             with open(f'{node_child.get_abs_path()}/config.yaml','r') as fid:
                  config=yaml.safe_load(fid)
-            particle=pd.read_parquet(
+            try:
+                #if True:
+            	particle=pd.read_parquet(
                      f"{node_child.get_abs_path()}/{config['particle_file']}")
-            df=pd.read_parquet(
+            	df=pd.read_parquet(
                      f'{node_child.get_abs_path()}/output_particles.parquet')
-            df['path 1']= f'{node.get_abs_path()}'
-            df['name 1']= f'{node.name}'
-            df['path 2']= f'{node_child.get_abs_path()}'
-            df['name 2']= f'{node_child.name}'
-            df['q1 final']=node_df['q1'].values[0]
-            df['q2 final']=node_df['q2'].values[0]
-            df['q1']=config_parent['qx0']
-            df['q2']=config_parent['qy0']
-            df=pd.merge(df, particle, on=["particle_id"])
-            my_list.append(df)
+            	df['path 1']= f'{node.get_abs_path()}'
+            	df['name 1']= f'{node.name}'
+            	df['path 2']= f'{node_child.get_abs_path()}'
+            	df['name 2']= f'{node_child.name}'
+            	#df['q1 final']=node_df['q1'].values[0]
+            	#df['q2 final']=node_df['q2'].values[0]
+            	df['q1']=config_parent['qx0']
+            	df['q2']=config_parent['qy0']
+            	df=pd.merge(df, particle, on=["particle_id"])
+            	my_list.append(df)
+            except:
+                problematic.append(node_child.get_abs_path())
+                print(f"problem {node_child.get_abs_path()}")
+	
 
     my_df = pd.concat(my_list)
     aux = my_df[my_df['state']!=1] # unstable

--- a/master_study/003_postprocessing.py
+++ b/master_study/003_postprocessing.py
@@ -55,7 +55,7 @@ if root.has_been('completed'):
             my_list.append(df)
 
     my_df = pd.concat(my_list)
-    aux = my_df[my_df['state']==0] # unstable
+    aux = my_df[my_df['state']!=1] # unstable
     print(pd.DataFrame([aux.groupby('name 1')['normalized amplitude in xy-plane'].min(),
                         aux.groupby('name 1')['q1'].mean(),
                         aux.groupby('name 1')['q2'].mean()

--- a/master_study/config.yaml
+++ b/master_study/config.yaml
@@ -22,7 +22,7 @@
         - clean_it.sh
       run_on: 'htc'
       htc_job_flavor: 'tomorrow' # optional parameter to define job flavor, default is espress
-  use_yaml_children: true
+  use_yaml_children: false
   # first generation
   children:
     '000_make_particle':

--- a/master_study/config.yaml
+++ b/master_study/config.yaml
@@ -13,13 +13,15 @@
       files_to_clone: # relative to the template folder
         - optics_specific_tools.py
         - clean_it.sh
-      run_on: 'local_pc'
+      run_on: 'htc'
+      htc_job_flavor: 'microcentury' # optional parameter to define job flavor, default is espresso
     3: # Launch the tracking
       job_folder: 'master_jobs/002_tracking_job'
       job_executable: 000_track.py # has to be a python file
       files_to_clone: # relative to the template folder
         - clean_it.sh
-      run_on: 'local_pc'
+      run_on: 'htc'
+      htc_job_flavor: 'tomorrow' # optional parameter to define job flavor, default is espress
   use_yaml_children: true
   # first generation
   children:

--- a/master_study/master_jobs/001_machine_model/config.yaml
+++ b/master_study/master_jobs/001_machine_model/config.yaml
@@ -35,7 +35,7 @@ optics_version: '1.5'
 # Enable checks
 check_betas_at_ips: true
 check_separations_at_ips: true
-save_intermediate_twiss: true
+save_intermediate_twiss: false
 
 # Tolerances for checks [ip1, ip2, ip5, ip8]
 tol_beta: 

--- a/master_study/master_jobs/002_tracking_job/000_track.py
+++ b/master_study/master_jobs/002_tracking_job/000_track.py
@@ -66,9 +66,9 @@ particles.particle_id = particle_df.particle_id.values
 # Symplify line #
 #################
 
-#line.remove_inactive_multipoles(inplace=True)
-#line.remove_zero_length_drifts(inplace=True)
-#line.merge_consecutive_drifts(inplace=True)
+line.remove_inactive_multipoles(inplace=True)
+line.remove_zero_length_drifts(inplace=True)
+line.merge_consecutive_drifts(inplace=True)
 #line.merge_consecutive_multipoles(inplace=True)
 
 #################

--- a/master_study/master_jobs/002_tracking_job/000_track.py
+++ b/master_study/master_jobs/002_tracking_job/000_track.py
@@ -36,7 +36,7 @@ with open(config['xline_json']) as fid:
 
 p_co = xp.Particles.from_dict(dd['particle_on_tracker_co'])
 line = xt.Line.from_dict(dd)
-R_matrix = dd['RR_finite_diffs']
+R_matrix = np.array(dd['RR_finite_diffs'])
 
 #####################################################
 # Get normalized coordinateds of particles to track #
@@ -66,10 +66,10 @@ particles.particle_id = particle_df.particle_id.values
 # Symplify line #
 #################
 
-line.remove_inactive_multipoles(inplace=True)
-line.remove_zero_length_drifts(inplace=True)
-line.merge_consecutive_drifts(inplace=True)
-line.merge_consecutive_multipoles(inplace=True)
+#line.remove_inactive_multipoles(inplace=True)
+#line.remove_zero_length_drifts(inplace=True)
+#line.merge_consecutive_drifts(inplace=True)
+#line.merge_consecutive_multipoles(inplace=True)
 
 #################
 # Build tracker #

--- a/master_study/user_defined_functions.py
+++ b/master_study/user_defined_functions.py
@@ -18,4 +18,4 @@ def generate_run_sh_htc(node, generation_number):
            f'source {node.root.parameters["setup_env_script"]}\n'
            f'cd {node.get_abs_path()}\n'
            f'python {python_command} > output.txt 2> error.txt\n'
-           f'rm -rf modules optics_repository optics_toolkit tools tracking_tools temp mad_collider.log __pycache__ twiss* errors fc* optics_orbit_at*\n')
+           f'rm -rf final_* modules optics_repository optics_toolkit tools tracking_tools temp mad_collider.log __pycache__ twiss* errors fc* optics_orbit_at*\n')

--- a/master_study/user_defined_functions.py
+++ b/master_study/user_defined_functions.py
@@ -7,3 +7,15 @@ def generate_run_sh(node, generation_number):
    return (f'source {node.root.parameters["setup_env_script"]}\n'
            f'cd {node.get_abs_path()}\n'
            f'python {python_command} > output.txt 2> error.txt\n')
+
+def generate_run_sh_htc(node, generation_number):
+   python_command =  (node
+                     .root
+                     .parameters["generations"]
+                     [generation_number]
+                     ["job_executable"])
+   return (f'#!/bin/bash\n'
+           f'source {node.root.parameters["setup_env_script"]}\n'
+           f'cd {node.get_abs_path()}\n'
+           f'python {python_command} > output.txt 2> error.txt\n'
+           f'rm -rf modules optics_repository optics_toolkit tools tracking_tools temp mad_collider.log __pycache__ twiss* errors fc* optics_orbit_at*\n')


### PR DESCRIPTION
Main changes:
1. run_on: 'htc' and 'slurm' is implemented
2. htc_job_flavor added in config.yaml (optional parameter), otherwise default job flavor is "espresso"
3. "generate_run_sh_htc" in user_defined_functions, main differences from lsf: #!/bin/bash is needed at the start of the script and some twiss/symbolic links are deleted after running
4. commented out "psutil.pids()" when run_on:'local_pc' as I was getting permission denied in lxplus
5. some minor fixes in 000_track.py 
6. fixed tree creation when use_yaml_children=False